### PR TITLE
Changed iOS saddr url part to "here" instead of Current+Location

### DIFF
--- a/src/ios/Directions.m
+++ b/src/ios/Directions.m
@@ -11,9 +11,9 @@
     NSString* url;
     if (address != nil) {
         address = [address stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]];
-        url = [NSString stringWithFormat:@"http://maps.apple.com/maps?saddr=Current+Location&daddr=%@", address];
+        url = [NSString stringWithFormat:@"http://maps.apple.com/maps?saddr=here&daddr=%@", address];
     } else {
-        url = [NSString stringWithFormat:@"http://maps.apple.com/maps?saddr=Current+Location&daddr=%@, %@", lat, lng];
+        url = [NSString stringWithFormat:@"http://maps.apple.com/maps?saddr=here&daddr=%@, %@", lat, lng];
     }
     [[UIApplication sharedApplication] openURL: [NSURL URLWithString: url]];
 


### PR DESCRIPTION
Apple-maps ignores "Current Location" name for source address in case of device is set to non-English lang. I tried "here" and it works just fine.